### PR TITLE
Add rollout + analysisTemplate for express-microservice

### DIFF
--- a/argocd/dev/app.express.yaml
+++ b/argocd/dev/app.express.yaml
@@ -8,7 +8,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: csdp-salesdemo-dev # temporarily set to Runtime namespace, CR-10565 
+    namespace: csdp-salesdemo-dev # temporarily set to Runtime namespace, CR-10565
     name: in-cluster
   project: express
   source:
@@ -18,5 +18,5 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-    automated:
-      prune: true
+    # automated:
+    #   prune: true

--- a/argocd/dev/app.express.yaml
+++ b/argocd/dev/app.express.yaml
@@ -1,4 +1,3 @@
-# Parent Argo CD app (grouping) for the flaskr apps
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -9,13 +8,15 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: express-microservice  # required field - set to your CF Runtume namespace
+    namespace: csdp-salesdemo-dev # temporarily set to Runtime namespace, CR-10565 
     name: in-cluster
   project: express
   source:
-    path: ./kustomize/express/overlays/dev  # Directory that contains the child apps
+    path: ./kustomize/express/overlays/dev
     repoURL: https://github.com/codefresh-contrib/csdp-salesdemo_applications.git
     targetRevision: main
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+    automated:
+      prune: true

--- a/argocd/prod-east/app.express.yaml
+++ b/argocd/prod-east/app.express.yaml
@@ -18,5 +18,5 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-    automated:
-      prune: true
+    # automated:
+    #   prune: true

--- a/argocd/prod-east/app.express.yaml
+++ b/argocd/prod-east/app.express.yaml
@@ -1,4 +1,3 @@
-# Parent Argo CD app (grouping) for the flaskr apps
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -9,15 +8,15 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: express-microservice  # required field - set to your CF Runtume namespace
+    namespace: csdp-salesdemo-prod-east # temporarily set to Runtime namespace, CR-10565
     name: in-cluster
   project: express
   source:
-    path: ./kustomize/express/overlays/prod-east  # Directory that contains the child apps
+    path: ./kustomize/express/overlays/prod-east
     repoURL: https://github.com/codefresh-contrib/csdp-salesdemo_applications.git
     targetRevision: main
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-    # automated:
-    #   prune: true
+    automated:
+      prune: true

--- a/argocd/stage/app.express.yaml
+++ b/argocd/stage/app.express.yaml
@@ -18,5 +18,5 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-    automated:
-      prune: true
+    # automated:
+    #   prune: true

--- a/argocd/stage/app.express.yaml
+++ b/argocd/stage/app.express.yaml
@@ -1,4 +1,3 @@
-# Parent Argo CD app (grouping) for the flaskr apps
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -9,15 +8,15 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: express-microservice  # required field - set to your CF Runtume namespace
+    namespace: csdp-salesdemo-stage # temporarily set to Runtime namespace, CR-10565
     name: in-cluster
   project: express
   source:
-    path: ./kustomize/express/overlays/stage  # Directory that contains the child apps
+    path: ./kustomize/express/overlays/stage
     repoURL: https://github.com/codefresh-contrib/csdp-salesdemo_applications.git
     targetRevision: main
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-    # automated:
-    #   prune: true
+    automated:
+      prune: true

--- a/kustomize/express/base/analysisTemplate.yaml
+++ b/kustomize/express/base/analysisTemplate.yaml
@@ -1,0 +1,65 @@
+# 2 AnalysisTemplates
+
+---
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: mixed-tests
+spec:
+  metrics:
+  - name: pass-2
+    count: 2
+    interval: 5s
+    failureLimit: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep-pass
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [exit 0]
+              restartPolicy: Never
+          backoffLimit: 0
+  - name: random-fail
+    count: 1
+    interval: 5s
+    failureLimit: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep-fail
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [FLIP=$(($(($RANDOM%10))%2)) && exit $FLIP]
+              restartPolicy: Never
+          backoffLimit: 0
+
+---
+kind: AnalysisTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: pass-always
+spec:
+  metrics:
+  - name: pass-5
+    count: 5
+    interval: 5s
+    failureLimit: 1
+    provider:
+      job:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: sleep
+                image: alpine:3.8
+                command: [sh, -c]
+                args: [exit 0]
+              restartPolicy: Never
+          backoffLimit: 0

--- a/kustomize/express/base/kustomization.yaml
+++ b/kustomize/express/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- deployment.yaml
+- analysisTemplate.yaml
+- rollout.yaml
+# - deployment.yaml
 - service.yaml

--- a/kustomize/express/base/rollout.yaml
+++ b/kustomize/express/base/rollout.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: express-microservice
+spec:
+  replicas: 4
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: express-microservice
+  template:
+    metadata:
+      labels:
+        app: express-microservice
+    spec:
+      containers:
+        - name: express-microservice
+          image: quay.io/codefresh_sa/express-microservice:3c23228
+          ports:
+            - containerPort: 3000
+      imagePullSecrets:
+      - name: quay-regcred
+  minReadySeconds: 30
+  strategy:
+    canary:
+      analysis:
+        templates:
+        - templateName: pass-always
+        # - templateName: mixed-tests
+        startingStep: 1
+      steps:
+        - setWeight: 25
+        - pause: {duration: 1m}

--- a/kustomize/express/base/rollout.yaml
+++ b/kustomize/express/base/rollout.yaml
@@ -15,7 +15,8 @@ spec:
     spec:
       containers:
         - name: express-microservice
-          image: quay.io/codefresh_sa/express-microservice:3c23228
+          # 3c23228 9ccb236
+          image: quay.io/codefresh_sa/express-microservice:9ccb236
           ports:
             - containerPort: 3000
       imagePullSecrets:


### PR DESCRIPTION
Hi @jcantosz, I think this should be good to go. I left the deployment.yaml intact (but no longer referenced by base kustomization.yaml) in case you need to compare it to rollout.yaml for debugging.